### PR TITLE
UX/btn: "Next ->" button easier to click 

### DIFF
--- a/web/src/components/common/Auth.tsx
+++ b/web/src/components/common/Auth.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { Button, Input, Box, VStack, Image, CloseButton, HStack, Text, IconButton, Progress } from '@chakra-ui/react';
+import { Button, Input, Box, VStack, Image, CloseButton, HStack, Text, Progress } from '@chakra-ui/react';
 import { login } from '../../state/auth/reducer'
 import { dispatch } from '../../state/dispatch'
 import {auth, auth as authModule} from '../../app/api'
@@ -84,12 +84,7 @@ const FeatureHighlightBubble = ({items}: {items: HighlightItem[]}) => {
           <HStack fontSize={"xs"} fontWeight={"bold"} alignItems={"center"} color={"minusxGreen.400"}>
             <BsLightbulbFill/><Box>Pro Tip {hintIdx + 1}/{numHints}</Box>
           </HStack>
-          <HStack fontSize={"xs"} fontWeight={"bold"} alignItems={"center"} color={"minusxGreen.400"}>
-            <Text fontSize="xs">Next</Text>
-            <IconButton icon={<BsArrowRight />} onClick={handleNext} variant={"ghost"} aria-label='next'/>
-
-          </HStack>
-          
+          <Button onClick={handleNext} variant="ghost" aria-label="Next" rightIcon={<BsArrowRight />} size="sm" fontWeight="bold">Next</Button>
         </HStack>
         <Progress
             value={progress}


### PR DESCRIPTION
When I first went through the tips I kept clicking on the text "Next" thinking it would be part of the button. Making sure the clickable part of button is clear and there's room to click is a goal of this PR. Users don't need to guess whether the icon or the word "Next" is the button if the text is added into the button.

- I removed `color={"minusxGreen.400"}` since `variant={"ghost"}` provides the color already
- `<HStack />` not needed since alignment and font size handled by `<Button />` 

## Comparing UI changes

https://github.com/user-attachments/assets/b2f2a04b-a454-43be-8ad4-1dbdb0f6662c

