### PR TITLE
UX: Made pro tips easier to close

### DIFF
--- a/web/src/components/common/Auth.tsx
+++ b/web/src/components/common/Auth.tsx
@@ -5,7 +5,7 @@ import { dispatch } from '../../state/dispatch'
 import {auth, auth as authModule} from '../../app/api'
 import { useSelector } from 'react-redux';
 import logo from '../../assets/img/logo.svg'
-import { BsLightbulbFill, BsArrowRight } from "react-icons/bs";
+import { BsLightbulbFill, BsArrowRight, BsFillLightningFill } from "react-icons/bs";
 import { getPlatformShortcut } from '../../helpers/platformCustomization'
 import { captureEvent, GLOBAL_EVENTS } from '../../tracking';
 import { capture } from '../../helpers/screenCapture/extensionCapture';
@@ -21,26 +21,15 @@ const FeatureHighlightBubble = ({items}: {items: HighlightItem[]}) => {
   const [isVisibile, setIsVisible] = useState(true)
   const [hintIdx, setHintIdx] = useState(0)
   const numHints = items.length
-  const [progress, setProgress] = useState(0);
-
-  useEffect(() => {
-    const timer = setInterval(() => {
-      setProgress((prevProgress) => {
-        if (prevProgress >= 100) {
-          handleNext();
-          return 0;
-        }
-        return prevProgress + 0.5;
-      });
-    }, 50);
-
-    return () => clearInterval(timer);
-  }, [hintIdx]);
+  const isLastTip = hintIdx === numHints - 1
 
   const handleNext = () => {
-    setHintIdx((hintIdx + 1) % numHints)
-    setProgress(0);
-  };
+    if (isLastTip) {
+      setIsVisible(false)
+    } else {
+      setHintIdx((hintIdx + 1) % numHints)
+    }
+  }
   
   return (
     isVisibile && <Box position="absolute"
@@ -84,21 +73,18 @@ const FeatureHighlightBubble = ({items}: {items: HighlightItem[]}) => {
           <HStack fontSize={"xs"} fontWeight={"bold"} alignItems={"center"} color={"minusxGreen.400"}>
             <BsLightbulbFill/><Box>Pro Tip {hintIdx + 1}/{numHints}</Box>
           </HStack>
-          <Button onClick={handleNext} variant="ghost" aria-label="Next" rightIcon={<BsArrowRight />} size="sm" fontWeight="bold">Next</Button>
+          <Button 
+            onClick={handleNext} 
+            variant="ghost" 
+            aria-label={isLastTip ? "Let's Go!" : "Next"} 
+            rightIcon={isLastTip ? <BsFillLightningFill /> : <BsArrowRight />}
+            size="sm" 
+            fontWeight="bold"
+          >
+            {isLastTip ? "Let's Go!" : "Next"}
+          </Button>
         </HStack>
-        <Progress
-            value={progress}
-            width="100%"
-            height={1}
-            position={"absolute"}
-            left={0}
-            bottom={0}
-            borderRadius={5}
-            colorScheme="minusxGreen"
-            size="sm"
-          />
-        </VStack>
-      
+      </VStack>
     </Box>
   );
 };


### PR DESCRIPTION
## Current functionality of tips
- Tips loop through indefinitely
- Only way to stop loop is to click the "X" button
- If you click the "Next ->" btn it loops to the beginning again even on last tip

## Problem
Users end up clicking the next btn multiple times to find out it doesn't turn into a "Done" button or they then end up finding a close button to stop the tips. A timer that automatically goes to the next tip doesn't make it easier for people to go through the onboarding. It leaves room for more assumptions on whether auto next feature also closes it. 

## Solution
- Rm looping tips
- On the last tip, change the 'Next ->' to 'Let's Go!' which will also act as a more natural closing btn(for this flow) for tips rather than clicking the X button in top right.
- "Let's Go" is better than "Done" because it makes me feel more excited like something cool is about to happen. MinusX is a taste of the future it should feel exciting. "Done" can sound boring(for this context) and feel like it's the DMV

<Br>

## Comparing UI changes

https://github.com/user-attachments/assets/cdd66b97-9cd2-4dba-89ab-5a82de3507e9

