### PR TITLE
Add live chat support when offline

### DIFF
--- a/web/src/components/common/Settings.tsx
+++ b/web/src/components/common/Settings.tsx
@@ -11,15 +11,8 @@ import { BsDiscord } from "react-icons/bs";
 import { PortalButton, SubscribeButton, PricingPlans } from './Subscription';
 import { getBillingInfo } from '../../app/api/billing';
 import { setBillingInfo } from '../../state/billing/reducer';
-import { SupportButton } from './Support';
 import { captureEvent, GLOBAL_EVENTS } from '../../tracking';
 import CreditsPill from './CreditsPill';
-
-const ACTIVE_TOOLS = {
-  jupyter: true,
-  metabase: true,
-  colab: false
-}
 
 const SettingsHeader = ({ text }: { text: string }) => (
   <Box position='relative' marginTop={2}>
@@ -140,7 +133,7 @@ const SettingsPage = () => {
           {billing.isSubscribed && <PortalButton />}
           <PricingPlans />
           <Text>
-            If you encounter any issues, contact us at support@minusx.ai or <SupportButton email={auth.email} showText={true} />
+            If you encounter any issues, contact us at support@minusx.ai or live support
           </Text>
         </VStack>
       </SettingsBlock>

--- a/web/src/components/common/Support.tsx
+++ b/web/src/components/common/Support.tsx
@@ -10,12 +10,6 @@ import { BiSupport } from "react-icons/bi"
 import axios from 'axios';
 import React, { useState, useEffect } from 'react'
 import { configs } from '../../constants'
-import { dispatch } from '../../state/dispatch';
-import { setIntercomBooted } from '../../state/settings/reducer';
-import { useSelector } from 'react-redux';
-import { RootState } from '../../state/store';
-
-
 
 export const SupportButton = ({email} : {email: string}) => {
   const {
@@ -25,13 +19,10 @@ export const SupportButton = ({email} : {email: string}) => {
     isOpen,
 
   } = useIntercom();
-  const intercomBooted = useSelector((state: RootState) => state.settings.demoMode)
+  const [intercomBooted, setIntercomBooted] = useState(false)
   const [hasNotification, setHasNotification] = useState(false)
-  const updateIntercomBooted = (value: boolean) => {
-    dispatch(setIntercomBooted(value))
-  }
   const toggleSupport = async () => isOpen ? hide() : show()
-   
+
   useEffect(() => {
     const bootIntercom = async () => {
       if (!intercomBooted) {
@@ -45,7 +36,7 @@ export const SupportButton = ({email} : {email: string}) => {
               name: email.split('@')[0],
               userHash: response.data.intercom_token,
             });
-            updateIntercomBooted(true);
+            setIntercomBooted(true);
             // Set up event listener for new messages
             window.Intercom('onUnreadCountChange', function(unreadCount: number) {
               setHasNotification(unreadCount > 0);

--- a/web/src/state/settings/reducer.ts
+++ b/web/src/state/settings/reducer.ts
@@ -87,16 +87,12 @@ export const settingsSlice = createSlice({
     setDemoMode: (state, action: PayloadAction<boolean>) => {
       state.demoMode = action.payload
     },
-    setIntercomBooted: (state, action: PayloadAction<boolean>) => {
-      state.intercomBooted = action.payload
-    }
   }
 })
 
 // Action creators are generated for each case reducer function
 export const { updateIsLocal, updateUploadLogs,
   updateIsAppOpen, updateAppMode, updateIsDevToolsOpen,
-  updateSidePanelTabName, updateDevToolsTabName, setSuggestQueries, setIframeInfo, setConfirmChanges, setDemoMode,
-  setIntercomBooted } = settingsSlice.actions
+  updateSidePanelTabName, updateDevToolsTabName, setSuggestQueries, setIframeInfo, setConfirmChanges, setDemoMode } = settingsSlice.actions
 
 export default settingsSlice.reducer


### PR DESCRIPTION
- Currently, if you're offline, you do not get the support notifications when you go online
- This PR adds a pulsing red dot as the notification
- It also triggers the messages to show up when you log in next time! Can actually enable 2 way comms!

<img width="347" alt="image" src="https://github.com/user-attachments/assets/9a9b986c-05fb-4c50-af39-79debdace84e">
