### PR TITLE
Make Viz Work

### DIFF
--- a/apps/src/metabase/actionDescriptions.ts
+++ b/apps/src/metabase/actionDescriptions.ts
@@ -1,5 +1,5 @@
 import { ActionDescription } from "../base/defaultState";
-import { visualizationTypes } from "./helpers/querySelectorMap";
+import { visualizationTypes } from "./helpers/types";
 
 export const COMMON_ACTION_DESCRIPTIONS: ActionDescription[] = [
   {
@@ -38,9 +38,23 @@ export const ACTION_DESCRIPTIONS_PLANNER: ActionDescription[] = [
         type: 'string',
         enum: visualizationTypes,
         description: "The type of visualization to set in the visualization settings."
+      },
+      dimensions: {
+        type: 'array',
+        items: {
+          type: 'string',
+        },
+        description: "The dimensions to set in the visualization settings. This is usually columns name for the x-axis, and the column to split the data by."
+      },
+      metrics: {
+        type: 'array',
+        items: {
+          type: 'string',
+        },
+        description: "The metrics to set in the visualization settings. This is usually the column name for the y-axis, or the metric to plot."
       }
     },
-    description: 'Sets the visualization type in the visualization settings. "queryExecuted" state must be true to use this tool.',
+    description: 'Sets the visualization type in the visualization settings. "queryExecuted" state must be true to use this tool. Always have at least one dimension and one metric.',
   },
   {
     name: 'getTableSchemasById',

--- a/apps/src/metabase/appController.ts
+++ b/apps/src/metabase/appController.ts
@@ -89,7 +89,8 @@ export class MetabaseController extends AppController<MetabaseAppState> {
         }
         currentCard.visualization_settings = visualization_settings;
       }
-      await RPCs.setVisualizationTypePrimary(currentCard);
+      await RPCs.dispatchMetabaseAction('metabase/qb/UPDATE_QUESTION', { card: currentCard });
+      await RPCs.dispatchMetabaseAction('metabase/qb/UPDATE_URL');
       return
     }
     const state = (await this.app.getState()) as MetabaseAppStateSQLEditor;

--- a/apps/src/metabase/appController.ts
+++ b/apps/src/metabase/appController.ts
@@ -20,6 +20,13 @@ import {
   DashcardDetails,
 } from "./helpers/dashboard/types";
 import _ from "lodash";
+import { 
+  VisualizationType,
+  primaryVisualizationTypes,
+  Card,
+  toLowerVisualizationType
+ } from "./helpers/types";
+
 
 export class MetabaseController extends AppController<MetabaseAppState> {
   async toggleSQLEditor(mode: "open" | "close") {
@@ -54,11 +61,37 @@ export class MetabaseController extends AppController<MetabaseAppState> {
     return actionContent;
   }
 
+
   async setVisualizationType({
     visualization_type,
+    dimensions,
+    metrics
   }: {
-    visualization_type: string;
+    visualization_type: VisualizationType,
+    dimensions?: string[],
+    metrics?: string[]
   }) {
+    // vivek: ensure the visualization type is capital case
+    function toCapitalCase(str: string) {
+      return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
+    }
+    visualization_type = toCapitalCase(visualization_type);    
+    console.log("Setting visualization type to", visualization_type, dimensions, metrics);
+    if (primaryVisualizationTypes.includes(visualization_type) && (dimensions && metrics)) {
+      const currentCard = await RPCs.getMetabaseState("qb.card") as Card;
+      if (currentCard) {
+        currentCard.display = toLowerVisualizationType(visualization_type);
+        const visualization_settings = {
+          "graph.dimensions": dimensions,
+          "graph.metrics": metrics,
+          "graph.series_order_dimension": null,
+          "graph.series_order": null
+        }
+        currentCard.visualization_settings = visualization_settings;
+      }
+      await RPCs.setVisualizationTypePrimary(currentCard);
+      return
+    }
     const state = (await this.app.getState()) as MetabaseAppStateSQLEditor;
     if (state.visualizationType === visualization_type.toLowerCase()) {
       return;

--- a/apps/src/metabase/appController.ts
+++ b/apps/src/metabase/appController.ts
@@ -89,9 +89,14 @@ export class MetabaseController extends AppController<MetabaseAppState> {
         }
         currentCard.visualization_settings = visualization_settings;
       }
-      await RPCs.dispatchMetabaseAction('metabase/qb/UPDATE_QUESTION', { card: currentCard });
-      await RPCs.dispatchMetabaseAction('metabase/qb/UPDATE_URL');
-      return
+      try {
+        await RPCs.dispatchMetabaseAction('metabase/qb/UPDATE_QUESTION', { card: currentCard });
+        await RPCs.dispatchMetabaseAction('metabase/qb/UPDATE_URL');
+        return
+      }
+      catch (error) {
+        console.error("Failed to update visualization type, falling back to UI method", error);
+      }
     }
     const state = (await this.app.getState()) as MetabaseAppStateSQLEditor;
     if (state.visualizationType === visualization_type.toLowerCase()) {

--- a/apps/src/metabase/helpers/DOMToState.ts
+++ b/apps/src/metabase/helpers/DOMToState.ts
@@ -61,6 +61,10 @@ export async function convertDOMtoStateSQLQuery() {
   const isShowingRawTable = await getMetabaseState('qb.uiControls.isShowingRawTable')
   const isShowingChartTypeSidebar = await getMetabaseState('qb.uiControls.isShowingChartTypeSidebar')
   const vizType = await getMetabaseState('qb.card.display')
+  const viz_settings = await getMetabaseState('qb.card.visualization_settings')
+  const viz_dimensions = viz_settings["graph.dimensions"]
+  const viz_metrics = viz_settings["graph.metrics"]
+
   const metabaseAppStateSQLEditor: MetabaseAppStateSQLEditor = {
     availableDatabases,
     selectedDatabaseInfo,
@@ -71,6 +75,8 @@ export async function convertDOMtoStateSQLQuery() {
     visualizationType: isShowingRawTable ? 'table' : vizType,
     visualizationSettingsStatus: isShowingChartTypeSidebar ? 'open' : 'closed',
     outputTableMarkdown,
+    viz_dimensions,
+    viz_metrics
   };
   if (sqlErrorMessage) {
     metabaseAppStateSQLEditor.sqlErrorMessage = sqlErrorMessage;

--- a/apps/src/metabase/helpers/DOMToState.ts
+++ b/apps/src/metabase/helpers/DOMToState.ts
@@ -61,9 +61,7 @@ export async function convertDOMtoStateSQLQuery() {
   const isShowingRawTable = await getMetabaseState('qb.uiControls.isShowingRawTable')
   const isShowingChartTypeSidebar = await getMetabaseState('qb.uiControls.isShowingChartTypeSidebar')
   const vizType = await getMetabaseState('qb.card.display')
-  const viz_settings = await getMetabaseState('qb.card.visualization_settings')
-  const viz_dimensions = viz_settings["graph.dimensions"]
-  const viz_metrics = viz_settings["graph.metrics"]
+  const visualization_settings = await getMetabaseState('qb.card.visualization_settings')
 
   const metabaseAppStateSQLEditor: MetabaseAppStateSQLEditor = {
     availableDatabases,
@@ -75,8 +73,7 @@ export async function convertDOMtoStateSQLQuery() {
     visualizationType: isShowingRawTable ? 'table' : vizType,
     visualizationSettingsStatus: isShowingChartTypeSidebar ? 'open' : 'closed',
     outputTableMarkdown,
-    viz_dimensions,
-    viz_metrics
+    visualization_settings
   };
   if (sqlErrorMessage) {
     metabaseAppStateSQLEditor.sqlErrorMessage = sqlErrorMessage;

--- a/apps/src/metabase/helpers/querySelectorMap.ts
+++ b/apps/src/metabase/helpers/querySelectorMap.ts
@@ -1,6 +1,5 @@
 import { QuerySelectorMap } from "extension/types";
-
-export const visualizationTypes = ["Table", "Bar", "Line", "Pie", "Row", "Area", "Combo", "Trend", "Funnel", "Detail", "Scatter", "Waterfall", "Number", "Gauge", "Progress", "Map", "PivotTable"]
+import { visualizationTypes } from "./types";
 
 const visualizationSelectors = Object.fromEntries(
   visualizationTypes.map((type) => [

--- a/apps/src/metabase/helpers/types.ts
+++ b/apps/src/metabase/helpers/types.ts
@@ -13,3 +13,28 @@ export interface FormattedTable {
   schema: string;
   columns?: { [key: number]: FormattedColumn };
 }
+
+export const visualizationTypes = ["Table", "Bar", "Line", "Pie", "Row", "Area", "Combo", "Trend", "Funnel", "Detail", "Scatter", "Waterfall", "Number", "Gauge", "Progress", "Map", "PivotTable"]
+export const primaryVisualizationTypes = ["Line", "Bar", "Area", "Scatter"]
+export type VisualizationType = typeof visualizationTypes[number];
+export type VisualizationTypeLower = Lowercase<VisualizationType>;
+export function toLowerVisualizationType(type: VisualizationType): VisualizationTypeLower {
+  return type.toLowerCase() as VisualizationTypeLower;
+}
+
+export interface Card {
+  dataset_query: {
+    database: number;
+    type: string;
+    [key: string]: any;
+  };
+  display: VisualizationTypeLower;
+  displayIsLocked: boolean;
+  visualization_settings: {
+    "graph.dimensions": string[];
+    "graph.metrics": string[];
+    [key: string]: any;
+  };
+  type: string;
+  [key: string]: any;
+}

--- a/apps/src/metabase/inject.ts
+++ b/apps/src/metabase/inject.ts
@@ -22,6 +22,11 @@ const setVisualizationTypePrimary = (card: any) => {
                 card: card
             }
         })
+        store.dispatch(
+            {
+                type: 'metabase/qb/UPDATE_URL'
+            }
+        )
     }
 }
 

--- a/apps/src/metabase/inject.ts
+++ b/apps/src/metabase/inject.ts
@@ -12,8 +12,22 @@ const getMetabaseState = (path: Parameters<typeof get>[1]) => {
     return null
 }
 
+const setVisualizationTypePrimary = (card: any) => {
+    const store = get(window, 'Metabase.store')
+    if (store && store.dispatch) {
+        console.log("DISPATCHING")
+        store.dispatch({
+            type: 'metabase/qb/UPDATE_QUESTION',
+            payload: {
+                card: card
+            }
+        })
+    }
+}
+
 export const rpc = {
-    getMetabaseState
+    getMetabaseState,
+    setVisualizationTypePrimary
 }
 
 initWindowListener(rpc)

--- a/apps/src/metabase/inject.ts
+++ b/apps/src/metabase/inject.ts
@@ -12,27 +12,19 @@ const getMetabaseState = (path: Parameters<typeof get>[1]) => {
     return null
 }
 
-const setVisualizationTypePrimary = (card: any) => {
+const dispatchMetabaseAction = (type: string, payload: any) => {
     const store = get(window, 'Metabase.store')
     if (store && store.dispatch) {
-        console.log("DISPATCHING")
         store.dispatch({
-            type: 'metabase/qb/UPDATE_QUESTION',
-            payload: {
-                card: card
-            }
+            type,
+            payload
         })
-        store.dispatch(
-            {
-                type: 'metabase/qb/UPDATE_URL'
-            }
-        )
     }
 }
 
 export const rpc = {
     getMetabaseState,
-    setVisualizationTypePrimary
+    dispatchMetabaseAction
 }
 
 initWindowListener(rpc)

--- a/web/src/app/rpc.ts
+++ b/web/src/app/rpc.ts
@@ -107,7 +107,7 @@ export const queryURL = () => sendMessage('queryURL', [])
 export const getMetabaseState = (path: Parameters<typeof get>[1]) =>
   sendMessage('getMetabaseState', [path], { log_rpc: true })
 export const dispatchMetabaseAction = (type: string, payload?: any) =>
-  sendMessage('dispatchMetabaseAction', [type, payload])
+  sendMessage('dispatchMetabaseAction', [type, payload], { log_rpc: true, timeout: 1000 })
 export const getJupyterState = (mode?: string) =>
   sendMessage('getJupyterState', [mode], { log_rpc: true, timeout: 3000 })
 export const getJupyterCodeOutput = (

--- a/web/src/app/rpc.ts
+++ b/web/src/app/rpc.ts
@@ -106,6 +106,8 @@ export const fetchData = (
 export const queryURL = () => sendMessage('queryURL', [])
 export const getMetabaseState = (path: Parameters<typeof get>[1]) =>
   sendMessage('getMetabaseState', [path], { log_rpc: true })
+export const setVisualizationTypePrimary = (card: any) =>
+  sendMessage('setVisualizationTypePrimary', [card])
 export const getJupyterState = (mode?: string) =>
   sendMessage('getJupyterState', [mode], { log_rpc: true, timeout: 3000 })
 export const getJupyterCodeOutput = (

--- a/web/src/app/rpc.ts
+++ b/web/src/app/rpc.ts
@@ -106,8 +106,8 @@ export const fetchData = (
 export const queryURL = () => sendMessage('queryURL', [])
 export const getMetabaseState = (path: Parameters<typeof get>[1]) =>
   sendMessage('getMetabaseState', [path], { log_rpc: true })
-export const setVisualizationTypePrimary = (card: any) =>
-  sendMessage('setVisualizationTypePrimary', [card])
+export const dispatchMetabaseAction = (type: string, payload?: any) =>
+  sendMessage('dispatchMetabaseAction', [type, payload])
 export const getJupyterState = (mode?: string) =>
   sendMessage('getJupyterState', [mode], { log_rpc: true, timeout: 3000 })
 export const getJupyterCodeOutput = (


### PR DESCRIPTION
Currently, we are at the mercy of Metabase picking the correct x, y axis values for visualizations. Implementing this on the UI is rather tricky. Vamsi from Metabase suggested that we look into the `viz_settings` json. This PR gets this to work!

- [x] Add viz change RPC
- [x] Make appropriate controller changes
- [x] Make appropriate action description changes
- [x] Add current viz settings to the state
- [x] Support primary viz types [Line, Scatter, Bar, Area]
- [x] Update URL

---
ToDos in a separate PR:
- Stacking, grouping, hiding lines etc
- Other viz types
- Make the LLM generate the entire json structure