### PR TITLE
Fix SQL Variable Overwrite

### DIFF
--- a/apps/src/metabase/helpers/sqlQuery.ts
+++ b/apps/src/metabase/helpers/sqlQuery.ts
@@ -1,0 +1,77 @@
+// helpers for generating metabase sql query related actions (specifically qb/UPDATE_QUESTION)
+import type { QBParameters, QBTemplateTags } from "./types";
+import { v4 as uuidv4 } from 'uuid';
+
+type VarAndUuids = {
+  variable: string,
+  uuid: string
+}[]
+ // not using this right now, but might be useful later?
+export const getVariablesAndUuidsInQuery = (query: string): VarAndUuids => {
+  const result: VarAndUuids = [];
+  const regex = /{{(\w+)}}/g;
+  let match;
+  while ((match = regex.exec(query)) !== null) {
+    result.push({
+      variable: match[1],
+      uuid: uuidv4()
+    });
+  }
+  return result;
+}
+
+function slugToDisplayName(slug: string): string {
+  return slug
+    .split('_')                  // Split the string by underscores
+    .map(word => 
+      word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
+    )                             // Capitalize the first letter of each word
+    .join(' ');                   // Join the words back with spaces
+}
+
+
+export function getTemplateTags(varsAndUuids: VarAndUuids, existingTemplateTags: QBTemplateTags): QBTemplateTags {
+  let templateTags: QBTemplateTags = {};
+  for (const {variable, uuid} of varsAndUuids) {
+    if (existingTemplateTags[variable]) {
+      templateTags[variable] = existingTemplateTags[variable];
+    } else {
+      // create a new template tag
+      templateTags[variable] = {
+        id: uuid,
+        type: 'text',
+        name: variable,
+        'display-name': slugToDisplayName(variable)
+      }
+    }
+  }
+  return templateTags;
+}
+
+export function getParameters(varsAndUuids: VarAndUuids, existingParameters: QBParameters): QBParameters {
+  let parameters: QBParameters = [];
+  for (const {variable, uuid} of varsAndUuids) {
+    // search in existing parameters to see if varName already exists
+    let existingParameter = existingParameters.find(param => param.slug === variable);
+    if (existingParameter) {
+      parameters.push(existingParameter);
+    } else {
+      // create a new parameter
+      parameters.push({
+        id: uuid,
+        type: 'category',
+        target: [
+          'variable',
+          [
+            'template-tag',
+            variable
+          ]
+        ],
+        name: slugToDisplayName(variable),
+        slug: variable
+      });
+    }
+  }
+  return parameters;
+}
+

--- a/apps/src/metabase/helpers/types.ts
+++ b/apps/src/metabase/helpers/types.ts
@@ -29,6 +29,31 @@ export interface visualizationSettings {
   [key: string]: any;
 }
 
+export interface QBParameter {
+  id: string,
+  type: string,
+  target: [
+    string, // 'variable'
+    [
+      "template-tag",
+      string // variable name
+    ]
+  ],
+  name: string, // display name
+  slug: string // also variable name
+}
+
+export type QBParameters = QBParameter[];
+export interface QBTemplateTag {
+  id: string,
+  type: string,
+  name: string,
+  default?: any,
+  'display-name': string,
+}
+export interface QBTemplateTags {
+  [key: string]: QBTemplateTag
+}
 // qb.card
 export interface Card {
   dataset_query: {
@@ -36,34 +61,14 @@ export interface Card {
     type: string;
     native: {
       query: string
-      'template-tags': {
-        [key: string]: {
-          id: string,
-          type: string,
-          name: string,
-          default: any,
-          'display-name': string,
-        }
-      }
+      'template-tags': QBTemplateTags
     }
   };
   display: VisualizationTypeLower;
   displayIsLocked: boolean;
   visualization_settings: visualizationSettings;
   type: string;
-  parameters: {
-    id: string,
-    type: string,
-    target: [
-      string, // 'variable'
-      [
-        "template-tag",
-        string // variable name
-      ]
-    ],
-    name: string, // display name
-    slug: string // also variable name
-  }[]
+  parameters: QBParameters;
 }
 
 // qb.parameterValues


### PR DESCRIPTION
- manually create actions for updateSQLQuery instead of drag-drop to UI and letting metabase handle it. (The issue with the latter is that sometimes metabase dispatches an in-between 'empty' sql action which causes loss of variable information. Instead of relying on metabase actions just manually dispatching it. this has some drawbacks (we're creating our own uuids for params so not sure metabase would respect them; haven't tested too much so high chance of breaking some metabase internal construct)