### PR TITLE
Fail in case of error during web deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ jobs:
         REF: ${{ github.sha }} # ref to checkout
       run: |
         ssh minusx@v1.minusxapi.com << EOF
+          set -e  # Exit on any error
           cd /home/minusx/minusx/web
           git fetch --all --tags
           git checkout $REF


### PR DESCRIPTION
Tested that using `set -e` will ensure EOF blocks fail in case of error in any intermediate command
<img width="775" alt="Screenshot 2024-10-31 at 14 08 55" src="https://github.com/user-attachments/assets/cf3015b5-01ca-4668-8672-89140d9ae325">
