### PR TITLE
prompt fixes for posthog; toolcall response fix

### DIFF
--- a/apps/src/posthog/actionDescriptions.ts
+++ b/apps/src/posthog/actionDescriptions.ts
@@ -40,11 +40,12 @@ export const ACTION_DESCRIPTIONS: ActionDescription[] = [
     },
     description: 'Gets the schemas of the specified tables by their ids in the database.',
   },
-  {
-    name: "getHogQLExpressionsDocumentation",
-    args: {},
-    description: "Gets the documentation for HogQL expressions. Use this tool if you need help with writing HogQL.",
-  },
+  // NOTE(@arpit): adding this to default system prompt for now.
+  // {
+  //   name: "getHogQLExpressionsDocumentation",
+  //   args: {},
+  //   description: "Gets the documentation for HogQL expressions. Use this tool if you need help with writing HogQL.",
+  // },
   {
     name: "getEventCommonProperties",
     args: {

--- a/apps/src/posthog/api.ts
+++ b/apps/src/posthog/api.ts
@@ -235,15 +235,15 @@ export interface CommonPropertiesResponse {
     property_type: string;
     is_seen_on_filtered_events: boolean;
     tags: string[];
-  }
+  }[]
 }
 
 export const getEventCommonProperties = async (eventNames: string[]) => {
   const projectId = await memoizedGetCurrentProjectId()
   if (projectId) {
     // a very shitty url but whatever
-    const commonPropertiesUrl = `/api/projects/${projectId}/property_definitions?limit=5&event_names=${JSON.stringify(eventNames.join(','))}&excluded_properties=${JSON.stringify(excluded_properties.join(','))}&is_feature_flag=false `
-    const response = await RPCs.fetchData(
+    const commonPropertiesUrl = `/api/projects/${projectId}/property_definitions?limit=20&event_names=${JSON.stringify(eventNames.join(','))}&excluded_properties=${JSON.stringify(excluded_properties.join(','))}&is_feature_flag=false `
+    const response: CommonPropertiesResponse = await RPCs.fetchData(
       commonPropertiesUrl,
       'GET', 
       undefined,
@@ -251,7 +251,7 @@ export const getEventCommonProperties = async (eventNames: string[]) => {
     ) as CommonPropertiesResponse
     return response
   } else {
-    console.warn("No current project found")
-    return []
+    console.warn("[minusx] No current project found in getEventCommonProperties")
+    return 
   }
 }

--- a/apps/src/posthog/docs/expressions.md
+++ b/apps/src/posthog/docs/expressions.md
@@ -13,6 +13,8 @@ HogQL expressions can access data like:
 
 Properties can be accessed with dot notation like `person.properties.$initial_browser` which also works for nested or JSON properties. They can also be accessed with bracket notation like `properties['$feature/cool-flag']`.
 
+> **Note:** `properties["$feature/cool-flag"]` is invalid syntax. You need to use single quotes like `properties['$feature/cool-flag']`.
+
 > **Note:** PostHog's properties always include `$` as a prefix, while custom properties do not (unless you add it).
 
 Property identifiers must be known at query time. For dynamic access, use the JSON manipulation functions from below on the `properties` field directly.

--- a/apps/src/posthog/prompts.ts
+++ b/apps/src/posthog/prompts.ts
@@ -2,6 +2,7 @@ import { getDescriptionsForEventDefinitions } from "./operations";
 import { PosthogAppStateSchema } from "./stateSchema";
 import hardcodedEventDefinitions from "./docs/hardcoded-event-definitions.json";
 import { formatEventDescriptionsAsYaml } from "./operations";
+import expressionsMd from "./docs/expressions.md?raw";
 
 export const DEFAULT_SYSTEM_PROMPT = `You are a master of Posthog and HogQL (which is a flavor of SQL for ClickHouse databases).
 
@@ -21,7 +22,6 @@ Routine to follow:
 4. Determine if you need to add HogQL, if so call the updateHogQLQueryAndExecute tool.
 5. If you estimate that the task can be accomplished with the tool calls selected in the current call, include the markTaskDone tool call at the end. Do not wait for everything to be executed.
 6. If you are waiting for the user's clarification, also mark the task as done.
-7. If you feel you need help with writing HogQL, call the getHogQLExpressionsDocumentation tool.
 
 For your reference, there is a description of the data model.
 
@@ -43,6 +43,12 @@ Here is a detailed list of event definitions and their descriptions.
 <EventDefinitions>
 ${formatEventDescriptionsAsYaml(getDescriptionsForEventDefinitions(hardcodedEventDefinitions))}
 </EventDefinitions>
+
+Here is documentation for HogQL expressions:
+
+<HogQLExpressionsDocs>
+${expressionsMd}
+</HogQLExpressionsDocs>
 
 <AppStateSchema>
 ${JSON.stringify(PosthogAppStateSchema)}


### PR DESCRIPTION
* added expresssions.md to default prompt; its pretty long now; also remove the toolcall to get fetch expressions.md
* fixed `getEventCommonProperties` response to be more meaningful in less tokens. this function is actually slightly misleading to the model sometimes, should fix that later
