### PR TITLE
catalog entities can be saved and viewed as snippets

### DIFF
--- a/apps/src/metabase/appController.ts
+++ b/apps/src/metabase/appController.ts
@@ -33,9 +33,11 @@ import {
   SearchApiResponse
  } from "./helpers/types";
 import {
-  getTemplateTags,
+  getTemplateTags as getTemplateTagsForVars,
   getParameters,
-  getVariablesAndUuidsInQuery
+  getVariablesAndUuidsInQuery,
+  MetabaseStateSnippetsDict,
+  getSnippetsInQuery
 } from "./helpers/sqlQuery";
 import axios from 'axios'
 import { getSelectedDbId, getUserInfo } from "./helpers/getUserInfo";
@@ -67,10 +69,15 @@ export class MetabaseController extends AppController<MetabaseAppState> {
       await this.toggleSQLEditor("open");
     }
     const currentCard = await RPCs.getMetabaseState("qb.card") as Card;
+    const allSnippetsDict = await RPCs.getMetabaseState("entities.snippets") as MetabaseStateSnippetsDict;
+    const snippetTemplateTags = getSnippetsInQuery(sql, allSnippetsDict);
     const varsAndUuids = getVariablesAndUuidsInQuery(sql);
     const existingTemplateTags = currentCard.dataset_query.native['template-tags'];
     const existingParameters = currentCard.parameters;
-    const templateTags = getTemplateTags(varsAndUuids, existingTemplateTags || {});
+    const templateTags = {
+      ...getTemplateTagsForVars(varsAndUuids, existingTemplateTags || {}),
+      ...snippetTemplateTags
+    }
     const parameters = getParameters(varsAndUuids, existingParameters || []);
     currentCard.dataset_query.native['template-tags'] = templateTags;
     currentCard.parameters = parameters;

--- a/apps/src/metabase/helpers/DOMToState.ts
+++ b/apps/src/metabase/helpers/DOMToState.ts
@@ -9,7 +9,7 @@ const { getMetabaseState, queryURL } = RPCs;
 import { Measure, Dimension, SemanticQuery, TableInfo } from "web/types";
 import { applyTableDiffs, handlePromise } from '../../common/utils';
 import { getSelectedDbId } from './getUserInfo';
-import { add, assignIn, find, get, keyBy, map } from 'lodash';
+import { add, assignIn, find, get, keyBy, map, omit } from 'lodash';
 import { getTablesFromSqlRegex } from './parseSql';
 
 interface ExtractedDataBase {
@@ -130,7 +130,6 @@ export function getTableContextYAML(relevantTablesWithFields: FormattedTable[]) 
     if (appSettings.drMode) {
         if (selectedCatalog) {
             const modifiedCatalog = modifyCatalog(selectedCatalog, relevantTablesWithFields)
-            console.log('modifiedCatalog', modifiedCatalog)
             tableContextYAML = {
                 ...modifiedCatalog,
             }
@@ -141,6 +140,20 @@ export function getTableContextYAML(relevantTablesWithFields: FormattedTable[]) 
         } 
     }
     return tableContextYAML
+}
+
+// replace {{snippet: snippetName}} with entity.name for the entity with entity.from_.alias = snippetName
+function modifySqlForSnippets(sql: string, entities: object[]) {
+  for (const entity of entities) {
+    const { name, from_ } = entity as any
+    if (typeof from_ != 'string') {
+      let {  alias } = from_
+      if (alias) {
+        sql = sql.replace(new RegExp(`{{\\s*snippet:\\s*${alias}\\s*}}`, 'g'), name)
+      }
+    }
+  }
+  return sql
 }
 
 export async function convertDOMtoStateSQLQuery() {
@@ -191,6 +204,10 @@ export async function convertDOMtoStateSQLQuery() {
   if (appSettings.drMode) {
     metabaseAppStateSQLEditor.tableContextYAML = tableContextYAML;
     metabaseAppStateSQLEditor.relevantTables = []
+    // if even one of the entities has useSnippets set to true, we need to rewrite sql
+    if (tableContextYAML?.entities.some(entity => get(entity, 'from_.useSnippets', false))) {
+      metabaseAppStateSQLEditor.sqlQuery = modifySqlForSnippets(metabaseAppStateSQLEditor.sqlQuery, tableContextYAML?.entities)
+    }
   }
   if (sqlErrorMessage) {
     metabaseAppStateSQLEditor.sqlErrorMessage = sqlErrorMessage;

--- a/apps/src/metabase/helpers/sqlQuery.ts
+++ b/apps/src/metabase/helpers/sqlQuery.ts
@@ -17,6 +17,46 @@ export const getVariablesAndUuidsInQuery = (query: string): VarAndUuids => {
   }
   return Object.entries(asMap).map(([key, value]) => ({ variable: key, uuid: value }));
 }
+export type MetabaseStateSnippetsDict = {
+  [key: string]: {
+    name: string,
+    id: number
+  }
+}
+type SnippetTemplateTag = {
+  "display-name": string,
+  id: string, // this is the uuid
+  name: string, // this looks like "snippet: snippetName"
+  "snippet-id": number,
+  "snippet-name": string // this is just snippetName
+  type: "snippet"
+}
+export const getSnippetsInQuery = (query: string, allSnippets: MetabaseStateSnippetsDict): {[key: string]: SnippetTemplateTag} => {
+  const regex = /{{(\s*snippet:\s*(\w+)\s*)}}/g;
+  let match;
+  let tags: SnippetTemplateTag[] = [];
+  while ((match = regex.exec(query)) !== null) {
+    const fullSnippetIdentifier = match[1];
+    const snippetName = match[2];
+    // search in allSnippets by snippetName to find the id
+    // the id is the key in allSnippets
+    let snippetId = Object.keys(allSnippets).find(id => allSnippets[id].name === snippetName);
+    if (!snippetId) {
+      console.warn(`Snippet ${snippetName} not found in allSnippets`);
+      snippetId = ""
+    }
+    tags.push({
+      "display-name": slugToDisplayName(snippetName),
+      id: uuidv4(),
+      name: fullSnippetIdentifier,
+      "snippet-id": parseInt(snippetId),
+      "snippet-name": snippetName,
+      type: "snippet"
+    })
+  }
+  // convert to dictionary with name as key
+  return Object.fromEntries(tags.map(tag => [tag.name, tag]))
+}
 
 function slugToDisplayName(slug: string): string {
   return slug

--- a/apps/src/metabase/helpers/types.ts
+++ b/apps/src/metabase/helpers/types.ts
@@ -52,6 +52,8 @@ export interface QBTemplateTag {
   name: string,
   default?: any,
   'display-name': string,
+  "snippet-id"?: number,
+  "snippet-name"?: string
 }
 export interface QBTemplateTags {
   [key: string]: QBTemplateTag

--- a/web/src/components/devtools/LLMContext.tsx
+++ b/web/src/components/devtools/LLMContext.tsx
@@ -161,7 +161,7 @@ export const LLMContext: React.FC<null> = () => {
     // removing this useEffect because its hurting my brain fixing it
     // useEffect(reloadAppState, [])
     const reloadMetabaseReduxState = () => {
-      const fieldsToFetch = ['qb', 'admin', 'dashboard']
+      const fieldsToFetch = ['qb', 'admin', 'dashboard', 'entities.snippets']
       const promises = fieldsToFetch.map( (field) => ( getMetabaseState(field)).then((data) => ({[field]: data}) ))
       Promise.all(promises).then((fieldsData) => {
         const data = fieldsData.reduce((acc, fieldData) => {


### PR DESCRIPTION
- implemented as metabase snippets
- snippets created/updated during catalog save (side-effects)
- consistently handle: User-facing catalog, user-facing sql, LLM -facing catalog, LLM-facing SQL
- handle template-tag changes for snippets