### PR TITLE
Increase table data cache TTL to 1 day in production

### DIFF
--- a/apps/src/metabase/helpers/parseTables.ts
+++ b/apps/src/metabase/helpers/parseTables.ts
@@ -2,7 +2,7 @@ import _, { flatMap, get } from 'lodash';
 import { memoize, RPCs, configs } from 'web'
 import { FormattedTable } from './types';
 
-export const DEFAULT_TTL = configs.IS_DEV ? 60 * 5 : 60 * 60;
+export const DEFAULT_TTL = configs.IS_DEV ? 60 * 5 : 60 * 60 * 24;
 
 export const extractTableInfo = (table: any, includeFields: boolean = false, schemaKey: string = 'schema'): FormattedTable => ({
   name: _.get(table, 'name', ''),


### PR DESCRIPTION
## Summary
- Increase table metadata cache from 1 hour to 24 hours in production
- Keep development cache at 5 minutes for faster iteration

## Changes Made
- Updated `DEFAULT_TTL` in `parseTables.ts` from `60 * 60` to `60 * 60 * 24` for production
- Maintains environment-aware caching with shorter TTL for development

## Rationale
- Table schemas and metadata change infrequently in production environments
- Longer cache reduces API load on Metabase servers
- Improves performance by reducing redundant metadata fetches
- Development maintains short cache for testing schema changes

## Test plan
- [ ] Verify table data is cached appropriately in both dev and prod environments
- [ ] Confirm cache expiration works correctly after 24 hours in production
- [ ] Test that dev mode still uses 5-minute cache for fast iteration

🤖 Generated with [Claude Code](https://claude.ai/code)