### PR TITLE
Model view UI

### DIFF
--- a/web/src/components/common/CatalogEditor.tsx
+++ b/web/src/components/common/CatalogEditor.tsx
@@ -70,7 +70,7 @@ export const updateCatalog = async ({ id, name, contents }: { id: string; name: 
 
 export const CatalogEditor: React.FC<CatalogEditorProps> = ({ onCancel, defaultTitle = '', defaultContent = '', id = '' }) => {
     const catalog: ContextCatalog | undefined = useSelector((state: RootState) => state.settings.availableCatalogs.find(catalog => catalog.id === id))
-    const [isViewing, setIsViewing] = useState(false);
+    // const [isViewing, setIsViewing] = useState(false);
     const origin = getParsedIframeInfo().origin
     if (catalog) {
         defaultTitle = catalog.name
@@ -137,8 +137,21 @@ export const CatalogEditor: React.FC<CatalogEditorProps> = ({ onCancel, defaultT
             {isSaving && (
                 <Text fontSize="sm" color="green.500" mb={2}>Saving...</Text>
             )}
-        <Text fontSize="md" fontWeight="bold">{defaultTitle ? 'Edit Catalog' : 'Create New Catalog'}</Text>
-        <Text fontSize="xs" color={"minusxGreen.600"} mb={3}><Link width={"100%"} textAlign={"center"} textDecoration={"underline"} href="https://docs.minusx.ai/en/articles/11166107-advanced-catalogs" isExternal>How to create a catalog?</Link></Text>
+        <HStack justifyContent="space-between" mb={4}>
+            <Text fontSize="md" fontWeight="bold">{defaultTitle ? 'Edit Catalog' : 'Create New Catalog'}</Text>
+            <HStack spacing={4} justifyContent="flex-end">
+                <Button size="xs" onClick={onCancel} variant="outline">Cancel</Button>
+                <Button 
+                    size="xs" 
+                    colorScheme="minusxGreen" 
+                    onClick={handleSave}
+                    isDisabled={!title.trim() || !yamlContent.trim() || isSaving}
+                >
+                    Save Catalog
+                </Button>
+            </HStack>
+        </HStack>
+        {/* <Text fontSize="xs" color={"minusxGreen.600"} mb={3}><Link width={"100%"} textAlign={"center"} textDecoration={"underline"} href="https://docs.minusx.ai/en/articles/11166107-advanced-catalogs" isExternal>How to create a catalog?</Link></Text> */}
         
         <Text fontSize="sm" mb={1}>Catalog Name</Text>
         <Input 
@@ -153,21 +166,17 @@ export const CatalogEditor: React.FC<CatalogEditorProps> = ({ onCancel, defaultT
         
         <HStack>
             <Text fontSize="sm" mb={1}>Catalog Definition (YAML)</Text>
-            <Button size="xs" variant="link" onClick={() => setIsViewing(!isViewing)}>
+            {/* <Button size="xs" variant="link" onClick={() => setIsViewing(!isViewing)}>
                 {isViewing ? 'Back to Edit' : 'Model View'}
-            </Button>
+            </Button> */}
         </HStack>
         
-        {isViewing ? (
-            <ModelView yamlContent={yamlContent} />
-            ) : (
-            <CodeEditor
-                height="400px"
-                language="yaml"
-                value={yamlContent}
-                onChange={(value) => setYamlContent(value || '')}
-            />
-        )}
+        <CodeEditor
+            height="400px"
+            language="yaml"
+            value={yamlContent}
+            onChange={(value) => setYamlContent(value || '')}
+        />
         {/* <Textarea
             placeholder="Enter YAML definition"
             value={yamlContent}
@@ -179,18 +188,6 @@ export const CatalogEditor: React.FC<CatalogEditorProps> = ({ onCancel, defaultT
             borderRadius="md"
             borderColor="gray.300"
         /> */}
-            
-            <HStack spacing={4} justifyContent="flex-end">
-                <Button size="sm" onClick={onCancel} variant="outline">Cancel</Button>
-                <Button 
-                    size="sm" 
-                    colorScheme="minusxGreen" 
-                    onClick={handleSave}
-                    isDisabled={!title.trim() || !yamlContent.trim() || isSaving}
-                >
-                    Save Catalog
-                </Button>
-            </HStack>
         </Box>
     );
 };

--- a/web/src/components/common/TablesCatalog.tsx
+++ b/web/src/components/common/TablesCatalog.tsx
@@ -43,7 +43,7 @@ export const resetRelevantTables = (relevantTables: TableInfo[], dbId: number) =
 export const TablesCatalog: React.FC<null> = () => {
   const toolContext: MetabaseContext = useAppStore((state) => state.toolContext)
   const tableDiff = useSelector((state: RootState) => state.settings.tableDiff)
-  const [isModelView, setIsModelView] = useState(false);
+//   const [isModelView, setIsModelView] = useState(false);
 
   const relevantTables = toolContext.relevantTables || []
   const dbInfo = toolContext.dbInfo

--- a/web/src/components/common/TablesCatalog.tsx
+++ b/web/src/components/common/TablesCatalog.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react"
 import { FilteredTable } from './FilterableTable';
 import { MetabaseContext } from 'apps/types';
 import { getApp } from '../../helpers/app';
-import { Text, Link, HStack, Button} from "@chakra-ui/react";
+import { Text, Link, HStack, Button, Tabs, TabList, TabPanels, TabPanel, Tab, VStack} from "@chakra-ui/react";
 import { applyTableDiff, TableInfo, resetDefaultTablesDB } from "../../state/settings/reducer";
 import { dispatch, } from '../../state/dispatch';
 import { useSelector } from 'react-redux';
@@ -78,12 +78,15 @@ export const TablesCatalog: React.FC<null> = () => {
 
   return <>
     <HStack w={"100%"} justify={"space-between"}>
-        <HStack>
-          <Text fontSize="md" fontWeight="bold">Catalog: Default Tables</Text>
-          <Button size="xs" variant="link" onClick={() => setIsModelView(!isModelView)}>
+        <VStack textAlign={"left"} alignItems={"flex-start"} justifyContent={"flex-start"} gap={0} m={0} p={0}>
+            <Text fontSize="md" fontWeight="bold">Catalog: Default Tables</Text>
+            <Text fontSize="xs" color={"minusxGreen.600"}><Link width={"100%"} textAlign={"left"} textDecoration={"underline"} href="https://docs.minusx.ai/en/articles/11166007-default-tables" isExternal>What are Default Tables?</Link></Text>
+    
+        </VStack>
+          {/* <Button size="xs" variant="link" onClick={() => setIsModelView(!isModelView)}>
               {isModelView ? 'Tables View' : 'Model View'}
-          </Button>
-        </HStack>
+          </Button> */}
+        <VStack alignItems={"flex-end"} justifyContent={"flex-end"} gap={0} m={0} p={0}>
         <Button 
             size={"xs"} 
             onClick={_resetRelevantTables} 
@@ -93,14 +96,28 @@ export const TablesCatalog: React.FC<null> = () => {
         >
             Reset to Smart Defaults
         </Button>
+        <Text fontSize="sm" color={"minusxGreen.600"} textAlign={"right"} fontWeight={"bold"}>[{validAddedTables.length} out of {allTables.length} tables selected]</Text>
+        </VStack>
         {/* <Text fontSize="sm" color={"minusxGreen.600"} textAlign={"right"}>[{validAddedTables.length} out of {allTables.length} tables selected]</Text> */}
     </HStack>
-    <Text fontSize="xs" color={"minusxGreen.600"}><Link width={"100%"} textAlign={"center"} textDecoration={"underline"} href="https://docs.minusx.ai/en/articles/11166007-default-tables" isExternal>What are Default Tables?</Link></Text>
-    {
+    <Tabs isFitted variant='enclosed-colored' colorScheme="minusxGreen" mt={5}>
+        <TabList mb='1em'>
+            <Tab><VStack gap={0} p={0} m={0}><Text>Catalog</Text><Text fontSize={"xs"} m={"-5px"}>[user editable]</Text></VStack></Tab>
+            <Tab><VStack gap={0} p={0} m={0}><Text>Preview</Text><Text fontSize={"xs"} m={"-5px"}>[what MinusX sees]</Text></VStack></Tab>
+        </TabList>
+        <TabPanels>
+            <TabPanel pt={0}>
+                <FilteredTable dbId={dbInfo.id} data={allTables} selectedData={validAddedTables} addFn={updateAddTables} removeFn={updateRemoveTables}/>
+            </TabPanel>
+            <TabPanel pt={0}>
+                <ModelView tables={validAddedTables} />
+            </TabPanel>
+        </TabPanels>
+    </Tabs>
+    {/* {
       isModelView ? (
         <ModelView tables={validAddedTables} />
       ) : <FilteredTable dbId={dbInfo.id} data={allTables} selectedData={validAddedTables} addFn={updateAddTables} removeFn={updateRemoveTables}/>
-    }
-    <Text fontSize="sm" color={"minusxGreen.600"} textAlign={"right"} fontWeight={"bold"}>[{validAddedTables.length} out of {allTables.length} tables selected]</Text>
+    } */}
   </>
 }

--- a/web/src/components/common/YAMLCatalog.tsx
+++ b/web/src/components/common/YAMLCatalog.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react"
-import { Text, Link, HStack, VStack, Button, Box } from "@chakra-ui/react";
+import { Text, Link, HStack, VStack, Button, Box, Tabs, TabList, TabPanels, TabPanel, Tab } from "@chakra-ui/react";
 import { useSelector } from 'react-redux';
 import { RootState } from '../../state/store';
 import { CodeBlock } from './CodeBlock';
@@ -38,7 +38,7 @@ export const YAMLCatalog: React.FC<null> = () => {
   const [isEditing, setIsEditing] = useState(false);
   const availableCatalogs: ContextCatalog[] = useSelector((state: RootState) => state.settings.availableCatalogs);
   const selectedCatalog = useSelector((state: RootState) => state.settings.selectedCatalog);
-  const [isModelView, setIsModelView] = useState(false);
+//   const [isModelView, setIsModelView] = useState(false);
   
   const currentCatalog = availableCatalogs.find(catalog => catalog.name === selectedCatalog);
   const yamlContent = dump(currentCatalog?.content || {});
@@ -66,16 +66,17 @@ export const YAMLCatalog: React.FC<null> = () => {
         {isDeleting && (
           <Text fontSize="md" fontWeight="bold">Deleting...</Text>
         )}
-        <HStack>
-          <Text fontSize="md" fontWeight="bold">Catalog: {currentCatalog?.name || 'None selected'}</Text>        
-          <Button size="xs" variant="link" onClick={() => setIsModelView(!isModelView)}>
+        <VStack textAlign={"left"} alignItems={"flex-start"} justifyContent={"flex-start"} gap={0} m={0} p={0}>
+          <Text fontSize="md" fontWeight="bold">Catalog: {currentCatalog?.name || 'None selected'}</Text>
+          <Text fontSize="xs" color={"minusxGreen.600"}><Link width={"100%"} textAlign={"center"} textDecoration={"underline"} href="https://docs.minusx.ai/en/articles/11166107-advanced-catalogs" isExternal>How to create a catalog?</Link></Text>
+          {/* <Button size="xs" variant="link" onClick={() => setIsModelView(!isModelView)}>
               {isModelView ? 'Catalog View' : 'Model View'}
-          </Button>
-        </HStack>
+          </Button> */}
+        </VStack>
         {!isEditing && (
             <HStack spacing={2}>
           <Button 
-            size="xs" 
+            size="xs"
             colorScheme="minusxGreen" 
             onClick={handleEditClick}
             isDisabled={isDeleting || !allowWrite}
@@ -97,26 +98,34 @@ export const YAMLCatalog: React.FC<null> = () => {
           </HStack>
         )}
       </HStack>
-      <Text fontSize="xs" color={"minusxGreen.600"}><Link width={"100%"} textAlign={"center"} textDecoration={"underline"} href="https://docs.minusx.ai/en/articles/11166107-advanced-catalogs" isExternal>How to create a catalog?</Link></Text>
       
-      {isEditing ? (
-        <CatalogEditor 
-          onCancel={handleCancelEdit} 
-          id={currentCatalog?.id || ''}
-        />
-      ) : isModelView ? (
-        <ModelView
-          yamlContent={yamlContent}
-        />
-      ) : (
-        <Box w="100%">
-            <CodeBlock 
-              code={yamlContent} 
-              tool="" 
-              language="yaml" 
-            />
-          </Box>
-      )}
+        <Tabs isFitted variant='enclosed-colored' colorScheme="minusxGreen" mt={5}>
+            <TabList mb='1em'>
+                <Tab><VStack gap={0} p={0} m={0}><Text>Catalog</Text><Text fontSize={"xs"} m={"-5px"}>[user editable]</Text></VStack></Tab>
+                <Tab><VStack gap={0} p={0} m={0}><Text>Preview</Text><Text fontSize={"xs"} m={"-5px"}>[what MinusX sees]</Text></VStack></Tab>
+            </TabList>
+            <TabPanels>
+                <TabPanel pt={0}>
+                    {isEditing ? (
+                        <CatalogEditor 
+                        onCancel={handleCancelEdit} 
+                        id={currentCatalog?.id || ''}
+                        />
+                    ) : (
+                        <Box w="100%">
+                            <CodeBlock 
+                            code={yamlContent} 
+                            tool="" 
+                            language="yaml" 
+                            />
+                        </Box>
+                    )}
+                </TabPanel>
+                <TabPanel pt={0}>
+                    <ModelView yamlContent={yamlContent} />
+                </TabPanel>
+            </TabPanels>
+        </Tabs>
     </VStack>
   );
 }

--- a/web/src/components/devtools/Context.tsx
+++ b/web/src/components/devtools/Context.tsx
@@ -183,9 +183,9 @@ export const Context: React.FC = () => {
         <Modal isOpen={isOpen} onClose={modalClose} size="3xl">
             <ModalOverlay />
             <ModalContent>
-                <ModalHeader>Catalogs</ModalHeader>
+                <ModalHeader>Context</ModalHeader>
                 <ModalCloseButton />
-                <ModalBody minH={"400px"} maxH={"600px"} overflowY={"auto"}>
+                <ModalBody minH={"400px"} maxH={"650px"} overflowY={"auto"}>
                     <CatalogDisplay isInModal={true} modalOpen={modalOpen}/>
                 </ModalBody>
             </ModalContent>


### PR DESCRIPTION
Tab like ui to separate out human facing and MinusX facing catalogs
- [x] UI for default tables
- [x] UI for yaml catalogs
<img width="502" alt="image" src="https://github.com/user-attachments/assets/3c889461-985b-4ea1-97ca-5b4651edb5d0" /><img width="849" alt="image" src="https://github.com/user-attachments/assets/7134784d-5e46-441c-9fee-a0b93505c13e" />

<img width="851" alt="image" src="https://github.com/user-attachments/assets/f0f8d04a-75fb-4b93-9c1a-480e940c8652" />
