### PR TITLE
Implement stale-while-revalidate caching pattern

### DIFF
--- a/web/src/cache/cache.ts
+++ b/web/src/cache/cache.ts
@@ -1,7 +1,7 @@
 import { getCache, setCache } from "./indexedDb"
 
-// Default TTL set to 5 days (5 days * 24 hours * 60 minutes * 60 seconds)
-export const DEFAULT_TTL = 5 * 24 * 60 * 60;
+// Default TTL set to 7 days (7 days * 24 hours * 60 minutes * 60 seconds)
+export const DEFAULT_TTL = 7 * 24 * 60 * 60;
 // Default rewarm TTL set to 12 hours
 export const DEFAULT_REWARM_TTL = 12 * 60 * 60;
 

--- a/web/src/cache/cache.ts
+++ b/web/src/cache/cache.ts
@@ -1,26 +1,58 @@
 import { getCache, setCache } from "./indexedDb"
 
-// Default TTL set to 1 week (7 days * 24 hours * 60 minutes * 60 seconds)
-export const DEFAULT_TTL = 7 * 24 * 60 * 60;
+// Default TTL set to 5 days (5 days * 24 hours * 60 minutes * 60 seconds)
+export const DEFAULT_TTL = 5 * 24 * 60 * 60;
+// Default rewarm TTL set to 12 hours
+export const DEFAULT_REWARM_TTL = 12 * 60 * 60;
 
 type AsyncFunction = (...args: any[]) => Promise<any>;
 /**
  * Memoizes a function with a TTL (time to live) and adds coalescing functionality
+ * Supports stale-while-revalidate pattern with rewarm TTL
  * 
  * @param fn - The function to memoize
  * @param ttl - The time to live in seconds. Negative values will never expire
- * @returns The memoized function with coalescing
+ * @param rewarmTtl - The rewarm time in seconds. If set, returns stale data while refreshing in background
+ * @returns The memoized function with coalescing and optional background refresh
  */
-export function memoize<T extends AsyncFunction>(fn: T, ttl: number = DEFAULT_TTL) {
+export function memoize<T extends AsyncFunction>(
+  fn: T, 
+  ttl: number = DEFAULT_TTL,
+  rewarmTtl: number = DEFAULT_REWARM_TTL
+) {
   const inProgressPromises: Record<string, Promise<Awaited<ReturnType<T>>> | null> = {};
 
   return async (...args: Parameters<T>): Promise<Awaited<ReturnType<T>>> => {
     const cacheKey = `${fn.name}-${JSON.stringify(args)}`;
+    const now = Date.now();
 
-    // Check if we have a valid cache
+    // Check if we have cached data
     const cachedResult = await getCache(cacheKey);
-    if (cachedResult && cachedResult.data && (cachedResult.createdAt + ttl * 1000 > Date.now() || ttl < 0)) {
-      return cachedResult.data;
+    
+    if (cachedResult && cachedResult.data) {
+      const age = now - cachedResult.createdAt;
+      const isExpired = age > ttl * 1000;
+      const needsRewarming = age > rewarmTtl * 1000;
+      
+      // If not expired, return cached data
+      if (!isExpired || ttl < 0) {
+        // If needs rewarming and no refresh in progress, trigger background refresh
+        if (needsRewarming && !inProgressPromises[cacheKey]) {
+          // Background refresh (don't await)
+          const backgroundPromise = fn(...args)
+            .then(async (result) => {
+              await setCache(cacheKey, result);
+              return result;
+            })
+            .finally(() => {
+              inProgressPromises[cacheKey] = null;
+            });
+          
+          inProgressPromises[cacheKey] = backgroundPromise;
+        }
+        
+        return cachedResult.data;
+      }
     }
 
     // Check if there's an ongoing promise


### PR DESCRIPTION
## Summary
- Implements stale-while-revalidate pattern for improved cache performance
- Adds rewarm TTL parameter (default 12 hours) to trigger background refresh
- Updates default cache TTL from 7 days to 5 days
- Returns cached data immediately while refreshing in background after rewarm time

## Benefits
- Eliminates blocking waits for expensive operations like database schema fetching
- Keeps data reasonably fresh through background updates
- Maintains all existing coalescing functionality
- Backwards compatible implementation

## Test plan
- [ ] Verify cached functions return immediately after rewarm TTL
- [ ] Confirm background refresh occurs without blocking
- [ ] Test that cache still expires after main TTL
- [ ] Validate coalescing still prevents duplicate requests

🤖 Generated with [Claude Code](https://claude.ai/code)