### PR TITLE
Remove redundant _client_type parameter from ExecuteSQLClient

### DIFF
--- a/apps/src/metabase/appController.ts
+++ b/apps/src/metabase/appController.ts
@@ -1,6 +1,6 @@
 import { BlankMessageContent, SemanticFilter, DefaultMessageContent, TimeDimension, Order } from "web/types";
 import { RPCs, configs } from "web";
-import { AppController, Action } from "../base/appController";
+import { AppController, Action, App } from "../base/appController";
 import {
   MetabaseAppState,
   MetabaseAppStateDashboard,
@@ -224,11 +224,14 @@ export class MetabaseController extends AppController<MetabaseAppState> {
       return {text: null, code: sql, oldCode: sqlQuery, language: "sql"}
     }
   })
-  async ExecuteSQLClient({ sql, _client_type, _ctes = [] }: { sql: string, _client_type?: string, _ctes?: CTE[] }) {
-    if (_client_type === MetabaseAppStateType.SQLEditor) {
+  async ExecuteSQLClient({ sql, _ctes = [] }: { sql: string, _ctes?: CTE[] }) {
+    const metabaseState = this.app as App<MetabaseAppState>;
+    const pageType = metabaseState.useStore().getState().toolContext?.pageType;
+    
+    if (pageType === 'sql') {
         return await this.updateSQLQuery({ sql, executeImmediately: true, _type: "csv", ctes: _ctes });
     }
-    else if (_client_type === MetabaseAppStateType.Dashboard) {
+    else if (pageType === 'dashboard') {
         return await this.runSQLQuery({ sql, ctes: _ctes });      
     }
   }


### PR DESCRIPTION
## Summary
- Removes the redundant `_client_type` parameter from the `ExecuteSQLClient` method
- Gets the page type directly from app state using `useStore().getState().toolContext?.pageType`
- Leverages the existing cross-boundary state management architecture

## Benefits
- Cleaner API that eliminates redundant parameters
- App controller already knows its context through state management
- Reduces coupling between planner and controller implementation details
- Follows the established pattern of accessing state via useStore()

## Changes
- Updated `ExecuteSQLClient` method signature to remove `_client_type` parameter
- Added logic to get pageType from app state instead of parameter
- Added import for `App` interface for proper typing

## Test plan
- [ ] Verify ExecuteSQLClient works correctly in SQL editor context
- [ ] Verify ExecuteSQLClient works correctly in dashboard context  
- [ ] Confirm no callers are still passing the removed parameter
- [ ] Test that page type detection works properly

🤖 Generated with [Claude Code](https://claude.ai/code)