### PR TITLE
Add "Explain SQL button"

### DIFF
--- a/apps/src/metabase/appState.ts
+++ b/apps/src/metabase/appState.ts
@@ -105,6 +105,29 @@ export class MetabaseState extends DefaultAppState<MetabaseAppState> {
       });
     })
 
+    const sqlSelector = querySelectorMap['native_query_top_bar']
+    const uniqueIDSQL = await RPCs.addNativeElements(sqlSelector, {
+      tag: 'button',
+      attributes: {
+        class: 'Button Button--primary',
+        style: 'background-color: #16a085; color: white; font-size: 15px; padding: 5px 10px; margin-left: 5px; border-radius: 5px; cursor: pointer;',
+      },
+      children: ['🔍 Explain SQL with MinusX']
+    })
+    addNativeEventListener({
+      type: "CSS",
+      selector: `#${uniqueIDSQL}`,
+    }, (event) => {
+      RPCs.toggleMinusXRoot('closed', false)
+      RPCs.addUserMessage({
+        content: {
+          type: "DEFAULT",
+          text: "Explain the current SQL query",
+          images: []
+        },
+      });
+    })
+
     const loginBoxSelector = querySelectorMap['login_box']
     const origin = getParsedIframeInfo().origin
     if (origin.includes('metabase.minusx.ai')) {

--- a/apps/src/metabase/appState.ts
+++ b/apps/src/metabase/appState.ts
@@ -87,7 +87,7 @@ export class MetabaseState extends DefaultAppState<MetabaseAppState> {
       tag: 'button',
       attributes: {
         class: 'Button Button--primary',
-        style: 'background-color: #16a085; color: white; font-size: 15px; padding: 5px 10px; margin-left: 5px; border-radius: 5px; cursor: pointer;',
+        style: 'background-color: #519ee4; color: white; font-size: 15px; padding: 5px 10px; margin-left: 5px; border-radius: 5px; cursor: pointer;',
       },
       children: ['✨ Fix with MinusX']
     })
@@ -110,7 +110,7 @@ export class MetabaseState extends DefaultAppState<MetabaseAppState> {
       tag: 'button',
       attributes: {
         class: 'Button Button--primary',
-        style: 'background-color: #16a085; color: white; font-size: 15px; padding: 5px 10px; margin-left: 5px; border-radius: 5px; cursor: pointer;',
+        style: 'background-color: #519ee4; color: white; padding: 5px 10px; margin-left: 5px; border-radius: 5px; cursor: pointer;',
       },
       children: ['🔍 Explain SQL with MinusX']
     })

--- a/apps/src/metabase/appState.ts
+++ b/apps/src/metabase/appState.ts
@@ -126,7 +126,7 @@ export class MetabaseState extends DefaultAppState<MetabaseAppState> {
           images: []
         },
       });
-    })
+    }, ['mouseup'])
 
     const loginBoxSelector = querySelectorMap['login_box']
     const origin = getParsedIframeInfo().origin

--- a/apps/src/metabase/helpers/querySelectorMap.ts
+++ b/apps/src/metabase/helpers/querySelectorMap.ts
@@ -102,5 +102,9 @@ export const querySelectorMap: QuerySelectorMap = {
     type: 'XPATH',
     selector: '//div[@id="DatabasePicker"]//div[contains(@class,"List-section") or @data-element-id="list-section"]/div/*'
   },
+  native_query_top_bar: {
+    type: 'XPATH',
+    selector: '//div[contains(@class, "GuiBuilder-data")] | //div[@data-testid="gui-builder-data"]'
+  },
   ...visualizationSelectors
 };

--- a/extension/src/content/RPCs/mutationObserver.ts
+++ b/extension/src/content/RPCs/mutationObserver.ts
@@ -42,7 +42,7 @@ const notifyNativeEvent = memoize((event: string, eventID: number) => {
             }
         })
     }
-})
+}, (event, eventID) => `${event}_${eventID}`)
 
 const _masterCallback = () => {
     const newResponses: SubscriptionResults = domQueries.map((query) => {

--- a/web/src/app/index.tsx
+++ b/web/src/app/index.tsx
@@ -66,7 +66,6 @@ const initRPCSync = (ref: React.RefObject<HTMLInputElement>) => {
             }
             if (rpcEvent.payload.key == 'nativeEvent') {
                 const payload = rpcEvent.payload.value
-                // @ppsreejith: Backward compatible hack.
                 onNativeEvent(payload)
             }
             if (rpcEvent.payload.key == 'recordingInProgress') {

--- a/web/src/app/rpc.ts
+++ b/web/src/app/rpc.ts
@@ -55,11 +55,11 @@ export const uClick = (selector: QuerySelector, index: number = 0) =>
   sendMessage('uClick', [selector, index], { log_rpc: true })
 export const uDblClick = (selector: QuerySelector, index: number = 0) =>
   sendMessage('uDblClick', [selector, index], { log_rpc: true })
-export const uHighlight = (
+export const uHighlight = async (
   selector: QuerySelector,
   index: number = 0,
   styles?: Partial<HTMLEmbedElement['style']>
-) => sendMessage('uHighlight', [selector, index, styles], { log_rpc: true })
+) => await sendMessage('uHighlight', [selector, index, styles], { log_rpc: true })
 export const scrollIntoView = (selector: QuerySelector, index: number = 0) =>
   sendMessage('scrollIntoView', [selector, index], { log_rpc: true })
 export const setMinusxMode = (mode: string) =>

--- a/web/src/package.ts
+++ b/web/src/package.ts
@@ -2,7 +2,7 @@ export * as RPCs from './app/rpc';
 export * as utils from './helpers/utils';
 export * as catalogAsModels from './helpers/catalogAsModels';
 export { memoize } from './cache/cache'
-export { subscribe } from './helpers/documentSubscription';
+export { subscribe, unsubscribe } from './helpers/documentSubscription';
 export { addNativeEventListener } from './helpers/nativeEvents';
 export { configs } from './constants';
 export { renderString } from './helpers/templatize';


### PR DESCRIPTION
- [x] Add explain sql button to the sql editor page
- [ ] This button should ideally be visible only when there is sql
- [ ] Fix bug that "Explain SQL" is sent as user message even when clicking on fix it. Why!?!?

--- 
Notes: I have been looking at the sql explanation and find it super useful. So maybe this button will be useful as well.
<img width="1140" alt="image" src="https://github.com/user-attachments/assets/01593c1c-565e-465c-8ba1-ad12c6fc1b61" />

