### PR TITLE
Handle old and new Metabase dbids

### DIFF
--- a/apps/src/metabase/appState.ts
+++ b/apps/src/metabase/appState.ts
@@ -146,7 +146,14 @@ export class MetabaseState extends DefaultAppState<MetabaseAppState> {
     // })
     subscribe(whitelistQuery, async ({elements, url}) => {
       const getState = this.useStore().getState
-      const toolEnabledNew = shouldEnable(elements, url);
+      const dbId = await getSelectedDbId();
+      let toolEnabledNew = shouldEnable(elements, url);
+      if (dbId === undefined || dbId === null) {
+        toolEnabledNew = {
+          value: false,
+          reason: "Unable to detect correct database. Please navigate to a SQL query page to enable MinusX."
+        }
+      }
       const pageType: MetabasePageType = determineMetabasePageType(elements, url);
       getState().update((oldState) => ({
         ...oldState,
@@ -157,7 +164,6 @@ export class MetabaseState extends DefaultAppState<MetabaseAppState> {
           url
         }
       }));
-      const dbId = await getSelectedDbId();
       const currentToolContext = getState().toolContext
       const oldDbId = get(currentToolContext, 'dbId')
       if (dbId && dbId !== oldDbId) {

--- a/apps/src/metabase/helpers/metabaseStateAPI.ts
+++ b/apps/src/metabase/helpers/metabaseStateAPI.ts
@@ -49,8 +49,16 @@ export async function getSelectedDbId(): Promise<number | undefined> {
   let dbId;
   
   if (isDashboard) {
-    const dashcards = await getMetabaseState('dashboard.dashcards') as any;
-    const dbIds = Object.values(dashcards || []).map((d: any) => d.card.database_id);
+    // const dashcards = await getMetabaseState('dashboard.dashcards') as any;
+    // const dbIds = Object.values(dashcards || []).map((d: any) => d.card.database_id);
+    // this is deprecated in new Metabase versions
+
+    const dashcards = await getMetabaseState('dashboard.dashcardData') as any;
+    const dbIds = Object.keys(dashcards).map(cardId => {
+                return Object.keys(dashcards[cardId]).map(key => {
+                    return dashcards[cardId][key]?.database_id;
+                });
+            });
     dbId = _.chain(dbIds).countBy().toPairs().maxBy(_.last).head().value();
     try {
       dbId = parseInt(dbId);


### PR DESCRIPTION
- Move from `dashcards` to `dashcardData`